### PR TITLE
fix: env config

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,4 +1,6 @@
-DISCORD_TOKEN="the discord bot token"
-SPOTIFY_USERNAME="your spotify email"
-SPOTIFY_PASSWORD="your spotify password"
-DISCORD_USER_ID="your discord id here"
+# you will have to insert your own values here 
+
+DISCORD_TOKEN="Mjk3ODQzNDgzNzgzODU2MjMw.SxDNko.UOdRWlDuz_lFrTOeQWEuzKGBmDFdVTGns3jd4o"
+SPOTIFY_USERNAME="mail@example.com"
+SPOTIFY_PASSWORD="MySpotifyPassword"
+DISCORD_USER_ID=301780655019130880

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -5,11 +5,14 @@ use figment::{
 use serde::{Deserialize};
 
 #[derive(Deserialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct Config {
+    #[serde(alias = "DISCORD_TOKEN")]
     pub discord_token: String,
+    #[serde(alias = "SPOTIFY_USERNAME")]
     pub spotify_username: String,
+    #[serde(alias = "SPOTIFY_PASSWORD")]
     pub spotify_password: String,
+    #[serde(alias = "DISCORD_USER_ID")]
     pub discord_user_id: u64,
 }
 
@@ -17,7 +20,7 @@ impl Config {
     pub fn new() -> Result<Self, Error> {
         let config: Config = Figment::new()
             .merge(Toml::file("config.toml"))
-            .merge(Env::raw().map(|v| v.to_string().to_lowercase().into()))
+            .merge(Env::raw())
             .extract()?;
         Ok(config)
     }


### PR DESCRIPTION
The [original fix](https://github.com/codetheweb/aoede/pull/18/commits/51e99dd1f13f9ffff5cdf7102978fcdf6539d9c5#diff-7492e7cd403313066a4b17311d40dea60b2cbea8555480f82d25ce4651b09637R9) doesn't work allow figment to deserialize the env values for whatever reason.