### PR TITLE
feat: add ability to customize autoplay from a configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aoede"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Max Isom <hi@maxisom.me>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aoede"
-version = "0.6.2"
+version = "0.6.1"
 authors = ["Max Isom <hi@maxisom.me>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ services:
       - DISCORD_TOKEN=
       - SPOTIFY_USERNAME=
       - SPOTIFY_PASSWORD=
-      - DISCORD_USER_ID=     # Discord user ID of the user you want Aoede to follow
-      - SPOTIFY_BOT_AUTOPLAY=
+      - DISCORD_USER_ID=        # Discord user ID of the user you want Aoede to follow
+      - SPOTIFY_BOT_AUTOPLAY=   # Autoplay similar songs when your music ends (true/false)
 ```
 
 ### Docker:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ services:
       - SPOTIFY_USERNAME=
       - SPOTIFY_PASSWORD=
       - DISCORD_USER_ID=     # Discord user ID of the user you want Aoede to follow
+      - SPOTIFY_BOT_AUTOPLAY=
 ```
 
 ### Docker:
@@ -53,6 +54,7 @@ DISCORD_TOKEN=
 SPOTIFY_USERNAME=
 SPOTIFY_PASSWORD=
 DISCORD_USER_ID=
+SPOTIFY_BOT_AUTOPLAY=
 ```
 
 ```bash

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -2,3 +2,4 @@ DISCORD_TOKEN="the discord bot token"
 SPOTIFY_USERNAME="your spotify email"
 SPOTIFY_PASSWORD="your spotify password"
 DISCORD_USER_ID="your discord id here"
+SPOTIFY_BOT_AUTOPLAY=true

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub spotify_password: String,
     #[serde(alias = "DISCORD_USER_ID")]
     pub discord_user_id: u64,
+    #[serde(alias = "SPOTIFY_BOT_AUTOPLAY")]
+    pub spotify_bot_autoplay: bool,
 }
 
 impl Config {

--- a/src/lib/player.rs
+++ b/src/lib/player.rs
@@ -37,6 +37,7 @@ pub struct SpotifyPlayer {
     pub spirc: Option<Box<Spirc>>,
     pub event_channel: Option<Arc<tokio::sync::Mutex<PlayerEventChannel>>>,
     mixer: Box<SoftMixer>,
+    pub bot_autoplay: bool,
 }
 
 pub struct EmittedSink {
@@ -206,6 +207,7 @@ impl SpotifyPlayer {
         password: String,
         quality: Bitrate,
         cache_dir: Option<String>,
+        bot_autoplay: bool,
     ) -> SpotifyPlayer {
         let credentials = Credentials::with_password(username, password);
 
@@ -256,6 +258,7 @@ impl SpotifyPlayer {
             spirc: None,
             event_channel: Some(Arc::new(tokio::sync::Mutex::new(rx))),
             mixer,
+            bot_autoplay,
         }
     }
 
@@ -265,7 +268,7 @@ impl SpotifyPlayer {
             device_type: DeviceType::AudioDongle,
             initial_volume: None,
             has_volume_ctrl: true,
-            autoplay: true,
+            autoplay: self.bot_autoplay,
         };
 
         let cloned_sink = self.emitted_sink.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,7 @@ async fn main() {
             config.spotify_password.clone(),
             Bitrate::Bitrate320,
             cache_dir,
+            config.spotify_bot_autoplay,
         )
         .await,
     ));


### PR DESCRIPTION
# This pull request makes the following changes:

* Possible fix for: #43

I implemented the autoplay setting through the config

# File changes:

* `Cargo.toml`: Bump version to 0.6.2
* `README.md`: Added new `SPOTIFY_BOT_AUTOPLAY` section for edit autoplay
* `config.sample.toml`: Added new `SPOTIFY_BOT_AUTOPLAY` section for edit autoplay
* `src/lib/config.rs`: Added `SPOTIFY_BOT_AUTOPLAY` section for correct parse configuration
* `src/lib/player.rs`: Using a `bot_autoplay` variable to set autoplay in AudioPlayer configuration  
* `src/main.rs`: Using `spotify_bot_autoplay` from the configuration to create an updated `SpotifyPlayer`