### PR TITLE
feat: added support for renaming the default Spotify device name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aoede"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "byteorder",
  "figment",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ services:
       - SPOTIFY_PASSWORD=
       - DISCORD_USER_ID=        # Discord user ID of the user you want Aoede to follow
       - SPOTIFY_BOT_AUTOPLAY=   # Autoplay similar songs when your music ends (true/false)
+      - SPOTIFY_DEVICE_NAME=
 ```
 
 ### Docker:
@@ -55,6 +56,7 @@ SPOTIFY_USERNAME=
 SPOTIFY_PASSWORD=
 DISCORD_USER_ID=
 SPOTIFY_BOT_AUTOPLAY=
+SPOTIFY_DEVICE_NAME=
 ```
 
 ```bash

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -3,3 +3,4 @@ SPOTIFY_USERNAME="your spotify email"
 SPOTIFY_PASSWORD="your spotify password"
 DISCORD_USER_ID="your discord id here"
 SPOTIFY_BOT_AUTOPLAY=true
+SPOTIFY_DEVICE_NAME="Aoede"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -3,4 +3,4 @@ SPOTIFY_USERNAME="your spotify email"
 SPOTIFY_PASSWORD="your spotify password"
 DISCORD_USER_ID="your discord id here"
 SPOTIFY_BOT_AUTOPLAY=true
-SPOTIFY_DEVICE_NAME="Aoede"
+SPOTIFY_DEVICE_NAME="custom device name in spotify, optional"

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -17,7 +17,12 @@ pub struct Config {
     #[serde(alias = "SPOTIFY_BOT_AUTOPLAY")]
     pub spotify_bot_autoplay: bool,
     #[serde(alias = "SPOTIFY_DEVICE_NAME")]
+    #[serde(default = "default_spotify_device_name")]
     pub spotify_device_name: String,
+}
+
+fn default_spotify_device_name() -> String{
+    "Aoede".to_string()
 }
 
 impl Config {

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub discord_user_id: u64,
     #[serde(alias = "SPOTIFY_BOT_AUTOPLAY")]
     pub spotify_bot_autoplay: bool,
+    #[serde(alias = "SPOTIFY_DEVICE_NAME")]
+    pub spotify_device_name: String,
 }
 
 impl Config {

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub spotify_device_name: String,
 }
 
-fn default_spotify_device_name() -> String{
+fn default_spotify_device_name() -> String {
     "Aoede".to_string()
 }
 

--- a/src/lib/player.rs
+++ b/src/lib/player.rs
@@ -261,7 +261,7 @@ impl SpotifyPlayer {
             event_channel: Some(Arc::new(tokio::sync::Mutex::new(rx))),
             mixer,
             bot_autoplay,
-            device_name
+            device_name,
         }
     }
 

--- a/src/lib/player.rs
+++ b/src/lib/player.rs
@@ -38,6 +38,7 @@ pub struct SpotifyPlayer {
     pub event_channel: Option<Arc<tokio::sync::Mutex<PlayerEventChannel>>>,
     mixer: Box<SoftMixer>,
     pub bot_autoplay: bool,
+    pub device_name: String,
 }
 
 pub struct EmittedSink {
@@ -208,6 +209,7 @@ impl SpotifyPlayer {
         quality: Bitrate,
         cache_dir: Option<String>,
         bot_autoplay: bool,
+        device_name: String,
     ) -> SpotifyPlayer {
         let credentials = Credentials::with_password(username, password);
 
@@ -259,12 +261,13 @@ impl SpotifyPlayer {
             event_channel: Some(Arc::new(tokio::sync::Mutex::new(rx))),
             mixer,
             bot_autoplay,
+            device_name
         }
     }
 
     pub async fn enable_connect(&mut self) {
         let config = ConnectConfig {
-            name: "Aoede".to_string(),
+            name: self.device_name.clone(),
             device_type: DeviceType::AudioDongle,
             initial_volume: None,
             has_volume_ctrl: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,7 @@ async fn main() {
             Bitrate::Bitrate320,
             cache_dir,
             config.spotify_bot_autoplay,
-            config.spotify_device_name.clone()
+            config.spotify_device_name.clone(),
         )
         .await,
     ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,6 +305,7 @@ async fn main() {
             Bitrate::Bitrate320,
             cache_dir,
             config.spotify_bot_autoplay,
+            config.spotify_device_name.clone()
         )
         .await,
     ));


### PR DESCRIPTION
This PR is an attempt to allow users to customize the name assigned to the Aoede device in Spotify, which is currently hardcoded to "Aoede". 

The struct in config.rs has been updated to map a new env variable "SPOTIFY_DEVICE_NAME" to spotify_device_name.  I have also updated the readme and config.sample.toml file appropriately.  

For backwards compatibility, I implemented a default value of "Aoede" using serde, so users aren't forced to add the new value when they update to the latest version.  

