### PR TITLE
fix lower case warnings on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:alpine as dependencies
+FROM rust:alpine AS dependencies
 
 RUN apk add --no-cache alpine-sdk cmake automake autoconf opus libtool
 RUN cargo install cargo-chef
 
-FROM dependencies as planner
+FROM dependencies AS planner
 WORKDIR app
 
 # We only pay the installation cost once,
@@ -13,12 +13,12 @@ WORKDIR app
 COPY . .
 RUN cargo chef prepare  --recipe-path recipe.json
 
-FROM dependencies as cacher
+FROM dependencies AS cacher
 WORKDIR app
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
-FROM dependencies as builder
+FROM dependencies AS builder
 WORKDIR app
 COPY . .
 # Copy over the cached dependencies
@@ -26,7 +26,7 @@ COPY --from=cacher /app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 RUN cargo build --release --bin aoede
 
-FROM alpine as runtime
+FROM alpine AS runtime
 WORKDIR app
 COPY --from=builder /app/target/release/aoede /usr/local/bin
 


### PR DESCRIPTION
Avoid warnings during Dockerfile builds by using upper case on FROM and AS statements.

Will remove following warnings from docker build:


WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                       0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)                                                                       0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)                                                                      0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 21)                                                                      0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)                                                                      0.0s